### PR TITLE
Slight changes in methods: _tokenTransfer and includeInReward

### DIFF
--- a/Safemoon.sol
+++ b/Safemoon.sol
@@ -866,7 +866,7 @@ contract SafeMoon is Context, IERC20, Ownable {
     }
 
     function includeInReward(address account) external onlyOwner() {
-        require(_isExcluded[account], "Account is already excluded");
+        require(_isExcluded[account], "Account is already included");
         for (uint256 i = 0; i < _excluded.length; i++) {
             if (_excluded[i] == account) {
                 _excluded[i] = _excluded[_excluded.length - 1];
@@ -1119,8 +1119,6 @@ contract SafeMoon is Context, IERC20, Ownable {
             _transferFromExcluded(sender, recipient, amount);
         } else if (!_isExcluded[sender] && _isExcluded[recipient]) {
             _transferToExcluded(sender, recipient, amount);
-        } else if (!_isExcluded[sender] && !_isExcluded[recipient]) {
-            _transferStandard(sender, recipient, amount);
         } else if (_isExcluded[sender] && _isExcluded[recipient]) {
             _transferBothExcluded(sender, recipient, amount);
         } else {


### PR DESCRIPTION
There is no need for the extra conditional statement when either accounts are not excluded since the last else handles it.
Replacing "exclude" to "include" in the includeInReward method